### PR TITLE
fix: make 7-day scrollback actually reach the client

### DIFF
--- a/lib/data/dataloader.js
+++ b/lib/data/dataloader.js
@@ -449,12 +449,12 @@ function loadFood(ddata, ctx, callback) {
 function loadDeviceStatus(ddata, env, ctx, callback) {
 
     const withFrame = ddata.page && ddata.page.frame;
-    // Default to 7 days so loop/pump device status is available across the full
-    // 7-day main-view scrollback (delivered via the retro path). Honor an
-    // explicit devicestatus.days setting so heavy loop deployments can dial the
-    // memory/bandwidth cost back down.
-    const configuredDays = env.extendedSettings.devicestatus && env.extendedSettings.devicestatus.days;
-    const days = configuredDays && !isNaN(Number(configuredDays)) ? Number(configuredDays) : 7;
+    // Device status load window (default 7 days via env.extendedSettings) so
+    // loop/pump status is available across the full main-view scrollback,
+    // delivered via the retro path. Heavy loop deployments can dial the
+    // memory/bandwidth cost back down with DEVICESTATUS_DAYS.
+    const days = env.extendedSettings.devicestatus && Number(env.extendedSettings.devicestatus.days)
+      ? Number(env.extendedSettings.devicestatus.days) : 7;
     const longLoad = days * constants.ONE_DAY;
     const loadTime = ctx.cache.isEmpty('devicestatus') || withFrame ? longLoad : constants.FIFTEEN_MINUTES;
 

--- a/lib/server/cache.js
+++ b/lib/server/cache.js
@@ -23,10 +23,17 @@ function cache (env, ctx) {
     , entries: []
   };
 
+  // Retention must be at least as long as the dataloader's query windows,
+  // otherwise the cache prunes the data before it reaches the client and the
+  // 7-day main-view scrollback would have no history. Mirrors loadEntries (7d),
+  // loadTreatments (7.5d) and loadDeviceStatus (configurable, default 7d).
+  const devicestatusDays = env.extendedSettings.devicestatus && Number(env.extendedSettings.devicestatus.days)
+    ? Number(env.extendedSettings.devicestatus.days) : 7;
+
   const retentionPeriods = {
-    treatments: constants.ONE_HOUR * 60
-    , devicestatus: env.extendedSettings.devicestatus && env.extendedSettings.devicestatus.days && env.extendedSettings.devicestatus.days == 2 ? constants.TWO_DAYS : constants.ONE_DAY
-    , entries: constants.TWO_DAYS
+    treatments: constants.SEVEN_DAYS + (constants.ONE_DAY / 2)
+    , devicestatus: devicestatusDays * constants.ONE_DAY
+    , entries: constants.SEVEN_DAYS
   };
 
   function getObjectAge(object) {

--- a/lib/server/env.js
+++ b/lib/server/env.js
@@ -215,8 +215,12 @@ function findExtendedSettings (envs) {
 
   extended.devicestatus = {};
   extended.devicestatus.advanced = true;
-  extended.devicestatus.days = 1;
-  if (shadowEnv['DEVICESTATUS_DAYS'] && shadowEnv['DEVICESTATUS_DAYS'] == '2') extended.devicestatus.days = 1;
+  // Default to 7 days so loop/pump status is available across the 7-day
+  // main-view scrollback; honor an explicit DEVICESTATUS_DAYS override.
+  extended.devicestatus.days = 7;
+  if (shadowEnv['DEVICESTATUS_DAYS'] && !isNaN(Number(shadowEnv['DEVICESTATUS_DAYS']))) {
+    extended.devicestatus.days = Number(shadowEnv['DEVICESTATUS_DAYS']);
+  }
 
   function normalizeEnv (key) {
     return key.toUpperCase().replace('CUSTOMCONNSTR_', '');


### PR DESCRIPTION
Follow-up to #25, which was merged before this fix was pushed. Without it the
7-day main-view scrollback silently still stops at ~48h.

Two server-side issues (flagged in review) prevented the longer window from
taking effect:

- **`lib/server/cache.js`** retained entries for only `TWO_DAYS` and treatments
  for 60h, so the new 7-day Mongo queries were pruned in the cache before being
  sent to the client. Retention now matches the loader windows: entries 7d,
  treatments 7.5d, devicestatus configurable (7d default).
- **`lib/server/env.js`** hard-coded `extendedSettings.devicestatus.days` to 1
  (the `DEVICESTATUS_DAYS == '2'` branch was a no-op), so the dataloader's 7-day
  default never applied. Default to 7 and honor an explicit `DEVICESTATUS_DAYS`
  override directly. Dataloader simplified to read the resolved value.

## Testing
- `env`, `dataloader`, `cache-objectid-compat` suites pass (integration tests
  use recent timestamps, so the longer retention doesn't perturb them).
- Server-only changes; no client bundle rebuild needed.
- Recommend a full `npm test` against a test mongo before merge for the
  DB-dependent suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)