### PR TITLE
Ignore compression lows toggle on stats reports

### DIFF
--- a/lib/report/compressionlows.js
+++ b/lib/report/compressionlows.js
@@ -1,0 +1,105 @@
+'use strict';
+
+// Compression-low detection.
+//
+// CGMs report false lows when the sensor is compressed (e.g. lying on it
+// overnight). These are not flagged in the data, so we detect them by their
+// characteristic shape: a brief overnight dip below threshold with a steep drop
+// in and a steep recovery out (a tight "V"). When enabled we drop the whole V
+// (drop + trough + recovery) from the stats.
+//
+// Operates on a single day's time-ordered statsrecords:
+//   { sgv: <display value>, bgValue: <mg/dL int>, displayTime: <Date> }
+// Detection is per-day so each series is contiguous; this misses Vs that
+// straddle local midnight, which is an accepted limitation.
+
+// Fixed, sensible defaults (mg/dL and minutes).
+var DEFAULTS = {
+  lowMgdl: 70           // only readings below this can be part of a compression low
+  , rateMgdlPerMin: 1.5 // minimum steepness of both the drop-in and the recovery-out
+  , limbWindowMin: 20   // how far before/after the trough to look for the steep limb
+  , maxTroughMin: 30    // compression troughs are brief; sustained lows are left alone
+  , nightStartHour: 22  // night window start (inclusive)
+  , nightEndHour: 8     // night window end (exclusive)
+};
+
+function isNight (date, cfg) {
+  var h = date.getHours();
+  return h >= cfg.nightStartHour || h < cfg.nightEndHour;
+}
+
+function minutesBetween (a, b) {
+  return Math.abs(b.getTime() - a.getTime()) / 60000;
+}
+
+// Returns the indices of records that belong to a suspected compression-low V.
+function detectIndexes (records, options) {
+  var cfg = Object.assign({}, DEFAULTS, options || {});
+  var flagged = [];
+  if (!records || records.length < 3) { return flagged; }
+
+  var i = 0;
+  while (i < records.length) {
+    if (records[i].bgValue < cfg.lowMgdl) {
+      // maximal run of consecutive readings below threshold (the trough)
+      var start = i;
+      var end = i;
+      while (end + 1 < records.length && records[end + 1].bgValue < cfg.lowMgdl) {
+        end++;
+      }
+
+      var troughMins = minutesBetween(records[start].displayTime, records[end].displayTime);
+      var atNight = isNight(records[start].displayTime, cfg) || isNight(records[end].displayTime, cfg);
+
+      if (atNight && troughMins <= cfg.maxTroughMin) {
+        // walk back along a strictly-falling limb into the trough
+        var dStart = start;
+        while (dStart - 1 >= 0
+            && records[dStart - 1].bgValue > records[dStart].bgValue
+            && minutesBetween(records[dStart - 1].displayTime, records[start].displayTime) <= cfg.limbWindowMin) {
+          dStart--;
+        }
+        // walk forward along a strictly-rising limb out of the trough
+        var rEnd = end;
+        while (rEnd + 1 < records.length
+            && records[rEnd + 1].bgValue > records[rEnd].bgValue
+            && minutesBetween(records[end].displayTime, records[rEnd + 1].displayTime) <= cfg.limbWindowMin) {
+          rEnd++;
+        }
+
+        var dropMins = minutesBetween(records[dStart].displayTime, records[start].displayTime);
+        var recMins = minutesBetween(records[end].displayTime, records[rEnd].displayTime);
+        var dropRate = dropMins > 0 ? (records[dStart].bgValue - records[start].bgValue) / dropMins : 0;
+        var recRate = recMins > 0 ? (records[rEnd].bgValue - records[end].bgValue) / recMins : 0;
+
+        // require evidence of BOTH a steep drop in and a steep recovery out
+        if (dropRate >= cfg.rateMgdlPerMin && recRate >= cfg.rateMgdlPerMin) {
+          for (var k = dStart; k <= rEnd; k++) { flagged.push(k); }
+        }
+      }
+
+      i = end + 1;
+    } else {
+      i++;
+    }
+  }
+
+  return flagged;
+}
+
+// Returns a copy of the day's records with suspected compression-low Vs removed.
+// Non-mutating, so toggling the option off restores the original records.
+function filterCompressionLows (records, options) {
+  if (!records || records.length < 3) { return records; }
+  var drop = detectIndexes(records, options);
+  if (!drop.length) { return records.slice(); }
+  var exclude = {};
+  for (var i = 0; i < drop.length; i++) { exclude[drop[i]] = true; }
+  return records.filter(function notExcluded (r, idx) { return !exclude[idx]; });
+}
+
+module.exports = {
+  DEFAULTS: DEFAULTS
+  , detectIndexes: detectIndexes
+  , filterCompressionLows: filterCompressionLows
+};

--- a/lib/report/reportclient.js
+++ b/lib/report/reportclient.js
@@ -191,6 +191,22 @@ var init = function init () {
         return setDataRange(event, days);
       });
       $('#rp_show').click(show);
+
+      // restore the persisted "ignore compression lows" state
+      $('#rp_ignorecompressionlows').prop('checked', require('./reportstorage').getValue('ignoreCompressionLows'));
+
+      // toggling recomputes instantly from already-loaded data (no server reload):
+      // rebuild allstatsrecords with/without compression lows, invalidate all
+      // rendered tabs and redraw the one currently in view.
+      $('#rp_ignorecompressionlows').change(function reRenderOnToggle () {
+        if (!lastShownOptions || !sorteddaystoshow.length) { return; }
+        lastShownOptions.ignoreCompressionLows = $(this).is(':checked');
+        require('./reportstorage').saveProps(lastShownOptions);
+        rebuildAllStatsRecords(lastShownOptions);
+        renderedPlugins = {};
+        var selected = $('.menutab.selected').attr('id');
+        if (selected) { maybeRenderPlugin(selected); }
+      });
       $('#rp_notes').bind('input', function(event) {
         $('#rp_enablenotes').prop('checked', true);
         return maybePrevent(event);
@@ -289,7 +305,8 @@ var init = function init () {
       }
       options.bgcheck = $('#rp_optionsbgcheck').is(':checked');
       options.othertreatments = $('#rp_optionsothertreatments').is(':checked');
-      
+      options.ignoreCompressionLows = $('#rp_ignorecompressionlows').is(':checked');
+
       const reportStorage = require('./reportstorage');
       reportStorage.saveProps(options);
       var matchesneeded = 0;
@@ -533,17 +550,31 @@ var init = function init () {
       return maybePrevent(event);
     }
 
-    function showreports (options) {
-      lastShownOptions = options;
-      // prepare some data used in more reports
+    var filterCompressionLows = require('./compressionlows').filterCompressionLows;
+
+    // Build the aggregated stats array consumed by the stats reports
+    // (Distribution, AGP/Statistics Summary, hourly, percentile, ...).
+    // Detection runs per calendar day so each series is contiguous and
+    // time-ordered; compression lows are excluded only when the toggle is on.
+    function rebuildAllStatsRecords (options) {
       datastorage.allstatsrecords = [];
       datastorage.alldays = 0;
       sorteddaystoshow.forEach(function eachDay (day) {
-        if (!daystoshow[day].treatmentsonly) {
-          datastorage.allstatsrecords = datastorage.allstatsrecords.concat(datastorage[day].statsrecords);
+        if (daystoshow[day] && !daystoshow[day].treatmentsonly) {
+          var dayRecords = datastorage[day].statsrecords;
+          if (options.ignoreCompressionLows) {
+            dayRecords = filterCompressionLows(dayRecords);
+          }
+          datastorage.allstatsrecords = datastorage.allstatsrecords.concat(dayRecords);
           datastorage.alldays++;
         }
       });
+    }
+
+    function showreports (options) {
+      lastShownOptions = options;
+      // prepare some data used in more reports
+      rebuildAllStatsRecords(options);
       options.maxInsulinValue = maxInsulinValue;
       options.maxCarbsValue = maxCarbsValue;
       options.maxDailyCarbsValue = maxDailyCarbsValue;

--- a/lib/report/reportstorage.js
+++ b/lib/report/reportstorage.js
@@ -14,7 +14,8 @@ const defaultValues = {
     insulindistribution: true,
     predictedTruncate: true,
     bgcheck: true,
-    othertreatments: false
+    othertreatments: false,
+    ignoreCompressionLows: false
 };
 let cachedProps;
 

--- a/tests/compressionlows.test.js
+++ b/tests/compressionlows.test.js
@@ -1,0 +1,68 @@
+'use strict';
+
+require('should');
+
+var cl = require('../lib/report/compressionlows');
+
+// Helper: build a day's time-ordered statsrecords from a list of mg/dL values
+// starting at a given hour, spaced 5 minutes apart.
+function series (startHour, mgdlValues) {
+  var base = new Date(2024, 0, 15, startHour, 0, 0, 0); // local time
+  return mgdlValues.map(function (v, i) {
+    var t = new Date(base.getTime() + i * 5 * 60000);
+    return { sgv: v / 18, bgValue: v, displayTime: t };
+  });
+}
+
+describe('compression lows', function () {
+
+  it('flags a sharp overnight V (steep drop + steep recovery)', function () {
+    // 02:00, drops 120 -> 55 in 15 min and recovers back in 15 min
+    var recs = series(2, [120, 95, 70, 55, 70, 95, 120, 120]);
+    var idx = cl.detectIndexes(recs);
+    idx.length.should.be.greaterThan(0);
+    // the trough (index 3, value 55) must be excluded
+    idx.indexOf(3).should.not.equal(-1);
+    // recovery limb up to first non-rising point is excluded (the whole V)
+    var filtered = cl.filterCompressionLows(recs);
+    filtered.length.should.be.lessThan(recs.length);
+    filtered.some(function (r) { return r.bgValue === 55; }).should.equal(false);
+  });
+
+  it('leaves a sustained overnight low untouched (real hypo, no fast recovery)', function () {
+    // a genuine slow low that lingers and recovers slowly
+    var recs = series(3, [90, 80, 70, 65, 63, 62, 64, 66, 68, 70, 72]);
+    var idx = cl.detectIndexes(recs);
+    idx.length.should.equal(0);
+    cl.filterCompressionLows(recs).length.should.equal(recs.length);
+  });
+
+  it('does not flag a daytime sharp V (outside the night window)', function () {
+    var recs = series(14, [120, 95, 70, 55, 70, 95, 120, 120]); // 14:00
+    cl.detectIndexes(recs).length.should.equal(0);
+  });
+
+  it('does not flag a sharp V that never dips below threshold', function () {
+    var recs = series(2, [120, 100, 85, 80, 85, 100, 120]); // trough 80 >= 70
+    cl.detectIndexes(recs).length.should.equal(0);
+  });
+
+  it('requires both a steep drop AND a steep recovery', function () {
+    // steep drop into the low but only a very slow drift back up
+    var recs = series(2, [120, 95, 70, 55, 57, 59, 61, 63, 65]);
+    cl.detectIndexes(recs).length.should.equal(0);
+  });
+
+  it('returns the input unchanged for tiny arrays', function () {
+    cl.filterCompressionLows([]).should.eql([]);
+    var two = series(2, [55, 60]);
+    cl.filterCompressionLows(two).length.should.equal(2);
+  });
+
+  it('respects custom thresholds', function () {
+    var recs = series(2, [120, 95, 70, 55, 70, 95, 120, 120]);
+    // raise the required steepness so the same V no longer qualifies
+    cl.detectIndexes(recs, { rateMgdlPerMin: 100 }).length.should.equal(0);
+  });
+
+});

--- a/views/reportindex.html
+++ b/views/reportindex.html
@@ -115,6 +115,13 @@
           </td>
           <td></td>
         </tr>
+        <tr>
+          <td colspan="2">
+            <label><input type="checkbox" id="rp_ignorecompressionlows">
+            <span class="translate">Ignore compression lows (overnight)</span></label>
+          </td>
+          <td></td>
+        </tr>
       </tr>
     </table>
     <button id="rp_show" class="translate">Show</button>


### PR DESCRIPTION
## Summary

Adds an **"Ignore compression lows (overnight)"** checkbox to the report
toolbar. When enabled, suspected overnight sensor-compression artifacts are
excluded from the glucose statistics on **Distribution**, **AGP**, and the
**Statistics Summary** (and the other `allstatsrecords`-based reports), so the
numbers reflect real glucose rather than pressure-induced false lows.

## How compression lows are detected

They are not flagged in the data, so they're detected by shape (a tight
overnight "V"):

- value **< 70 mg/dL**
- occurs **22:00–08:00**
- **steep drop in** and **steep recovery out** (both ≥ ~1.5 mg/dl/min), trough brief

The whole V (drop + trough + recovery) is removed, not just the lowest point.
Requiring *both* a steep drop and a steep recovery, plus the night-window
restriction, avoids excluding genuine treated daytime lows.

## Implementation

- Detection lives in a small, dependency-free module `lib/report/compressionlows.js`
  with fixed sensible defaults (easy to tune in one place).
- The filter is applied once where every stats report gets its data — when
  building `datastorage.allstatsrecords` in `reportclient.js` — so all stats
  reports pick it up consistently. Detection runs per calendar day (each series
  contiguous/time-ordered).
- Non-mutating, so unticking restores the originals.
- Toggling recomputes instantly from already-loaded data (no server reload) and
  re-renders the visible tab; the choice persists via `reportstorage`.

## Testing

- New unit tests `tests/compressionlows.test.js` (7 passing): sharp overnight V
  flagged; sustained real hypo left alone; daytime V ignored; never-below-threshold
  ignored; requires both limbs steep; tiny-array safety; custom thresholds.
- Reports integration test passes; client bundle rebuilds cleanly.

## Notes / limitations

- Thresholds are fixed in code (70 mg/dL, 1.5 mg/dl/min, 22:00–08:00) — worth
  tuning against real data after trying it.
- Detection is per calendar day, so a V straddling local midnight may be missed
  (rare for typical 01:00–05:00 lows).
- It's a heuristic; it won't perfectly separate compression from fast-treated lows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)