### PR TITLE
fix: apply compression-low filtering to Daily Stats

### DIFF
--- a/lib/report_plugins/dailystats.js
+++ b/lib/report_plugins/dailystats.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var consts = require('../constants');
+var compressionlows = require('../report/compressionlows');
 
 var dailystats = {
   name: 'dailystats'
@@ -84,7 +85,12 @@ dailystats.report = function report_dailystats (datastorage, sorteddaystoshow, o
   sorteddaystoshow.forEach(function(day) {
     var tr = $('<tr>');
 
+    // Daily Stats reads the per-day records directly (not allstatsrecords), so
+    // apply the same overnight compression-low filtering here when enabled.
     var daysRecords = datastorage[day].statsrecords;
+    if (options && options.ignoreCompressionLows) {
+      daysRecords = compressionlows.filterCompressionLows(daysRecords);
+    }
 
     if (daysRecords.length === 0) {
       $('<td/>').appendTo(tr);


### PR DESCRIPTION
Follow-up to #27 (already merged). Review noted that the compression-low
toggle didn't reach the **Daily Stats** report.

Daily Stats reads the per-day `datastorage[day].statsrecords` directly
(`lib/report_plugins/dailystats.js`) rather than the filtered
`datastorage.allstatsrecords`, so overnight compression lows still affected its
low counts, min, averages and percentiles even with the global toggle checked.

This applies the same non-mutating `filterCompressionLows()` at that read site
when `options.ignoreCompressionLows` is set, so the toggle is now honored
consistently across **all** stats reports. Daily Stats is the only report that
reads the per-day array directly; every other stats report already uses the
filtered `allstatsrecords`.

## Testing
- Existing compression-low unit tests (7) and reports integration test pass.
- Bundle rebuilds cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)